### PR TITLE
Fix incorrect date when editing a never-messaged entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,10 @@
                     state.people.forEach(displayPerson);
                 }
             }
+
+            function setLastMessagedToNow() {
+                $('#editlast').val(moment().format('YYYY-MM-DD'))
+            }
         </script>
         <style>
             p, label, input {
@@ -208,7 +212,7 @@
                 <label for="editfrequency"> every </label><input id="editfrequency" type="number"></input><label> days</label>
                 <br/>
                 <label for="editlast"> last messaged on </label><input id="editlast" type="date"></input>
-                <button onclick="$('#editlast').val(moment().format('YYYY-MM-DD'))" type="button">now</button>
+                <button onclick="setLastMessagedToNow()" type="button">now</button>
                 <br/>
                 <button onclick=editFromForm() type="button">Save</button>
                 <button onclick=removeFromForm() type="button">Remove</button>

--- a/index.html
+++ b/index.html
@@ -73,7 +73,11 @@
                 $("#editid").val(person.id);
                 $("#editname").val(person.name);
                 $("#editfrequency").val(person.frequency);
-                $("#editlast").val(moment(person.lastMessaged).format("YYYY-MM-DD"));
+                if (person.lastMessaged === 0) {
+                    setLastMessagedToNow()
+                } else {
+                    $("#editlast").val(moment(person.lastMessaged).format("YYYY-MM-DD"));
+                }
                 $("#editPersonContainer").css("display", "block")
                 $("#darkness").css("display", "block");
             }


### PR DESCRIPTION
Currently, after creating a new reminder, editing the entry and then saving without doing anything changes the last message date from 'never' to 1970-01-01, as this is the date represented by a timestamp of 0.

This PR changes the behaviour of the entry edit UI to first check if the last messaged date is 0; if it is, then the last messaged date will be set to the current time. This will not affect entries with a stored date of 1970-01-01 (including erroneous entries created before this PR), as these will be recorded as `"1970-01-01"` rather than `0`.

A better long-term solution would be to use a non-numeric value e.g. `null` to represent 'never', and then add a dedicated 'never' button to the date picker.